### PR TITLE
add Eitr food support

### DIFF
--- a/FoodSlots.cs
+++ b/FoodSlots.cs
@@ -10,9 +10,14 @@ public class FoodSlots
     [HarmonyPatch(typeof(Hud), "UpdateFood", new[] { typeof(Player) })]
     static class FoodColorPatch
     {
-        static readonly Color healthFoodColor = new Color(1f, 0.333f, 0.333f, 0.35f); // Red color for health food
-        static readonly Color staminaFoodColor = new Color(1f, 0.9513f, 0.2941f, 0.3f); // Orange color for stamina food
-        static readonly Color defaultColor = new Color(0f, 0f, 0f, 0.5375f); // Default color when food is inactive
+        // Manually set up our alpha value to be the same as vanilla food HUD
+        const float ALPHA = 0.503f;
+
+        // Set our colors using vanilla food icon colors but replacing alpha with HUD alpha
+        private static Color SetFoodColor(Color color, float alpha = ALPHA) => new(color.r, color.g, color.b, alpha);
+        static readonly Color healthFoodColor = SetFoodColor(InventoryGui.instance.m_playerGrid.m_foodHealthColor);
+        static readonly Color staminaFoodColor = SetFoodColor(InventoryGui.instance.m_playerGrid.m_foodStaminaColor);
+        static readonly Color defaultColor = SetFoodColor(Color.black);
 
         static void Postfix(Hud __instance)
         {

--- a/FoodSlots.cs
+++ b/FoodSlots.cs
@@ -17,6 +17,7 @@ public class FoodSlots
         private static Color SetFoodColor(Color color, float alpha = ALPHA) => new(color.r, color.g, color.b, alpha);
         static readonly Color healthFoodColor = SetFoodColor(InventoryGui.instance.m_playerGrid.m_foodHealthColor);
         static readonly Color staminaFoodColor = SetFoodColor(InventoryGui.instance.m_playerGrid.m_foodStaminaColor);
+        static readonly Color eitrFoodColor = SetFoodColor(InventoryGui.instance.m_playerGrid.m_foodEitrColor);
         static readonly Color defaultColor = SetFoodColor(Color.black);
 
         static void Postfix(Hud __instance)
@@ -37,15 +38,19 @@ public class FoodSlots
                 if (foodImage != null && food.m_time > 0)
                 {
                     Color foodColor = defaultColor;
-                    if (food.m_health > food.m_stamina)
+                    // Decide which color to assign using the same logic as for vanilla food icon colors
+                    if (food.m_eitr / 2f > food.m_health && food.m_eitr / 2f > food.m_stamina)
                     {
-                        foodColor = healthFoodColor; // Red color for health food
+                        foodColor = eitrFoodColor;
                     }
-                    else if (food.m_health < food.m_stamina)
+                    else if (food.m_health / 2f > food.m_stamina)
                     {
-                        foodColor = staminaFoodColor; // Orange color for stamina food
+                        foodColor = healthFoodColor;
                     }
-
+                    else if (food.m_stamina / 2f > food.m_health)
+                    {
+                        foodColor = staminaFoodColor;
+                    }
                     foodImage.color = foodColor;
                 }
                 else if (foodImage != null)


### PR DESCRIPTION
This adds support for Eitr food with a blue-colored background.

We additionally rework the logic for deciding which color to assign to a food slot using the same logic as for vanilla food icon colors (the small fork in the top right corner of foods in the inventory), for consistency between food slot colors and food icon colors.

We take this opportunity to also retrieve the colors used in vanilla for food icons and use them as the basis for our own colors. This way, the colors are now consistent and also we might get lucky on updates and have the colors automagically update if food icons are updated.

Didn't manage to find where the vanilla alpha value for the HUD was defined but we can at least manually set it up to be the exact same as in vanilla, as seen by inspecting the HUD with UnityExplorer.